### PR TITLE
WIP: [MANOPD-71406] Passivating for service with healthz from allowedStandbyStateList

### DIFF
--- a/modules/stateful.py
+++ b/modules/stateful.py
@@ -63,7 +63,7 @@ def run_service(service, options, procedure, force, no_wait):
             logging.info(f"Service: {service}. Check current health status")
             healthz_resp = utils.send_get(url=options['parameters']["healthzEndpoint"])
 
-            if healthz_resp["status"].lower() != "up" and procedure == "standby":
+            if healthz_resp["status"].lower() not in options["allowedStandbyStateList"] and procedure == "standby":
 
                 logging.critical(
                     f"Service: {service}. Current health status is {healthz_resp['status'].lower()}. Service failed")

--- a/sm-client
+++ b/sm-client
@@ -839,7 +839,7 @@ def main_func(procedure, site, run_services, skip_services, force):
         thread.join()
 
     for service in services_to_run:
-        for site in sites_name:
+        for site in sites_to_process:
             if not procedure_results[service][site]:
                 procedure_results[service][site] = {'healthz': '--', 'mode': '--', 'status': '--'}
 
@@ -850,7 +850,7 @@ def main_func(procedure, site, run_services, skip_services, force):
     logging.info(f"services that ignored:           {ignored_services}")
     logging.info("---------------------------------------------------------------------")
 
-    print_additional_table(procedure_results, services_to_run, sites_name)
+    print_additional_table(procedure_results, services_to_run, sites_to_process)
     # Clear working lists
     running_procedure = ""
     running_services = []


### PR DESCRIPTION
### Brief issue/feature description

* It is necessary to add the ability to passivate the service with the `healthz` status not equal to `Up`.

### How it was fixed/implemented

* It is now considered acceptable in the case of passivation at the beginning of the procedure to have the `healthz` status from the `allowedStandbyStateList`.