### PR TITLE
[MANOPD-73172] added exit code = 1 if any service failed

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -924,7 +924,9 @@ def main_func(procedure, site, run_services, skip_services, force):
     print_additional_table(procedure_results, services_to_run, sites_to_process)
 
     if len(failed_services) != 0:
+        logging.fatal(f"Some services finished {procedure} with failed status")
         exit(1)
+
     # Clear working lists
     running_procedure = ""
     running_services = []


### PR DESCRIPTION
### Brief issue/feature description

* Some pipelanes may require exit codes to understand successfulness on any procedure.

### How it will be fixed/implemented

* SM-Client will return exit code = 1 at the end of all procedure if it for some service turns out as failure.
