### PR TITLE
Update cacert default value

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -66,7 +66,6 @@ parser.add_argument('-v', '--verbose', default=False, action='store_true', help=
 parser.add_argument('-c', '--config', default="", help='define the path to configuration file')
 parser.add_argument('-f', '--force', default=False, action='store_true', help='force apply DR action and ignore healthz')
 parser.add_argument('-k', '--insecure', default=False, action='store_true', help='enable self-signed certificates')
-parser.add_argument('--cacert', default='', help='define path to CA cert for self-signed certificates')
 parser.add_argument('--run-services', default='', help='define the list of services to apply DR action, by default all services participate')
 parser.add_argument('--skip-services',  default='', help='define the list of services what will not participate in DR action')
 
@@ -522,9 +521,9 @@ def create_sm_dict(sites, procedure, sites_active, sites_standby, skip_services)
             exit(1)
 
         site_token = [ i.get("token", "") for i in conf_parsed["sites"] if i ["name"] == site ][0]
-        site_cacert = [ i.get("cacert", "") for i in conf_parsed["sites"] if i ["name"] == site ][0]
+        site_cacert = [ i.get("cacert", True) for i in conf_parsed["sites"] if i ["name"] == site ][0]
 
-        if site_cacert != '' and not os.path.isfile(site_cacert):
+        if site_cacert != True and not os.path.isfile(site_cacert):
             logging.fatal(f"You should define correct path to CA certificate for site {site}")
             exit(1)
 


### PR DESCRIPTION
**Brief issue/feature description**

 - Add ability to use CA certificate for self-signed `site-manager` certificate

**How it was fixed/implemented**

 - update sm-client
 - set `cacert` parameter in config.yaml with path to certificate for each of cluster