### PR TITLE
remove running state as error

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -231,7 +231,7 @@ class ServiceDRStatus:
 
     def is_ok(self):
         """ @todo wrong-service ?"""
-        if self.healthz in ['down','degraded','--'] or self.status in ['failed','running']:
+        if self.healthz in ['down','degraded','--'] or self.status in ['failed']:
             return False
         return True
 

--- a/tests/selftest/test_smclient.py
+++ b/tests/selftest/test_smclient.py
@@ -423,7 +423,7 @@ def test_sm_poll_service_required_status(mocker, caplog):
 def test_sm_process_service_with_polling(mocker, caplog):
     smclient.args=args_init()
     init_and_check_config(args_init())
-    test_resp={'services':{'serv1':{'healthz':'up', 'mode':'active', 'status':'running'}}}
+    test_resp={'services':{'serv1':{'healthz':'up', 'mode':'active', 'status':'failed'}}}
     caplog.set_level(logging.DEBUG)
     fake_resp=mocker.Mock()
     fake_resp.json=mocker.Mock(return_value=test_resp)


### PR DESCRIPTION
Some services may change dr status procedure to in-progress after it is done actually. Need to handle such case for now.
### 
_2022-11-18 11:49:20,935 [DEBUG] utils.py.io_make_http_json_request(126): REST response: {'services': {'opensearch-opensearch': {'healthz': '**degraded**', 'message': '', 'mode': '**standby**', 'status': '**done**'}}}
2022-11-18 11:49:25,940 [INFO] sm-client.service_status_polling(805): Service: opensearch-opensearch. Site: right-kubernetes. Polling procedure mode to be ['**active**'] Iteration 3
2022-11-18 11:49:25,941 [DEBUG] utils.py.io_make_http_json_request(112): REST data: {'procedure': 'status', 'run-service': 'opensearch-opensearch'}
2022-11-18 11:49:26,063 [DEBUG] utils.py.io_make_http_json_request(126): REST response: {'services': {'opensearch-opensearch': {'healthz': '**up**', 'message': '', 'mode': '**active**', 'status': '**running**'}}}
2022-11-18 11:49:26,064 [INFO] sm-client.service_status_polling(805): Service: opensearch-opensearch. Site: right-kubernetes. Polling procedure healthz to be ['**up**'] Iteration 1
2022-11-18 11:49:26,064 [DEBUG] utils.py.io_make_http_json_request(112): REST data: {'procedure': 'status', 'run-service': 'opensearch-opensearch'}
2022-11-18 11:49:31,242 [DEBUG] utils.py.io_make_http_json_request(126): REST response: {'services': {'opensearch-opensearch': {'healthz': '**up**', 'message': '', 'mode': 'active', 'status': '**running**'}}}_
 