### PR TITLE
[MANOPD-81751] - fix update cr vaidation & warn root user in tests

### DIFF
--- a/site-manager.py
+++ b/site-manager.py
@@ -222,7 +222,8 @@ def cr_validate():
 
     # Check name for unique
     sm_dict = get_sitemanagers_dict()
-    if cr["name"] in sm_dict['services'].keys():
+    existed_cr = sm_dict['services'].get(cr['name'], None)
+    if existed_cr is not None and existed_cr['namespace'] != cr['namespace']:
         allowed = False
         message = f"CR with name {cr['name']} has already existed in cluster"
         logging.debug(f"CR validation fails: {message}")


### PR DESCRIPTION
* Don't return unique CR name error, if user update parameters for existed CR;
* Warn, if root user was used in pytest
* Remove logging files in tests after using it