### PR TITLE
[MANOPD-81953] Polling site-manager flow in idempotent way

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -235,7 +235,7 @@ class ServiceDRStatus:
              self.service = data['wrong-service']
          else:
              raise ValueError("Missing service name")
-         serv= data['services'][self.service] if data.get('services') else data
+         serv = data['services'][self.service] if data.get('services') else data
          self.mode = serv['mode'] if serv.get("mode") in ["active", "standby", "disable"] else "--"
          self.nowait = serv["nowait"] if serv.get("nowait") else False
          self.healthz = serv["healthz"] if serv.get("healthz") in ["up", "down", "degraded"] else "--"
@@ -244,7 +244,6 @@ class ServiceDRStatus:
          # https://github.com/Netcracker/DRNavigator/blob/b4161fb15271485974abf5862e7272abc386fbc8/modules/stateful.py#L16
 
     def is_ok(self):
-        """ @todo wrong-service ?"""
         if self.healthz in ['down','degraded','--'] or self.status in ['failed']:
             return False
         return True
@@ -833,10 +832,11 @@ def sm_poll_service_required_status(site, service, mode, sm_dict, force: bool = 
     """ Polls service status command till desired mode is reached
         @param force: True/False --force mode to ignore healthz
     """
-    def service_status_polling(site, service, expected_state, error_state, delay=5) -> Tuple[Dict,bool]:
-        """  Polls "site-manager status" <service> command till <state> dict returns during <timeout> period with <delay>
-        @param state:  expected dict state from site-manager service status command. {"status": ["up"]}
-        @param error_state: optional error state which should be processed immediately. {"status": ["failed"]}
+    def service_status_polling(site, service, expected_state, error_state, delay=5) -> Dict:
+        """  Polls "site-manager status" <service> command till <expected_state> dict or
+        error_state dict returns during <timeout> period with <delay>
+        @param expected_state:  expected dict state from site-manager service status command. {"status": ["up"]}
+        @param error_state:  error state in case return immediately. {"status": ["failed"]}
         """
         timeout = sm_dict[site]["services"][service]["timeout"] if sm_dict[site]["services"].get(service, {})\
                                                                        .get("timeout", None) is not None  else \
@@ -857,21 +857,24 @@ def sm_poll_service_required_status(site, service, mode, sm_dict, force: bool = 
             logging.info(f"Service: {service}. Site: {site}. Received data: {data}. Return code: {ret}")
 
             if ret and all(data["services"][service][key] in val for key, val in expected_state.items()):
-                return data, ret
+                return data
             elif ret and any(data["services"][service][key] in val for key, val in error_state.items()):
-                return data, False
+                logging.info(f"Service: {service}. Site: {site}. Error state occurred.")
+                return data
             else:
                 time.sleep(delay)
                 continue
-        return data, False
+
+        logging.info(f"Service: {service}. Site: {site}. Timeout expired.")
+        return data
 
     if mode == "standby":
-        data, ret = service_status_polling(site, service,
+        data = service_status_polling(site, service,
                                            {"status": ["done"], "mode": [mode], "healthz":
                                                sm_dict[site]["services"][service]["allowedStandbyStateList"]},
                                            {'status': ['failed'], 'healthz': ['down', 'degraded']})
     else:  # active and rest commands
-        data, ret = service_status_polling(site, service,
+        data = service_status_polling(site, service,
                                          {"status": ["done"], "mode": [mode], "healthz": ["up"]},
                                          {'status': ['failed'], 'healthz': ['down', 'degraded']})
 

--- a/tests/selftest/test_smclient.py
+++ b/tests/selftest/test_smclient.py
@@ -342,7 +342,7 @@ def test_ServiceDRStatus_init():
         assert ServiceDRStatus()
         assert ServiceDRStatus({'services':{}})
 
-    stat=ServiceDRStatus({'message':'You defined service that does not exist in cluster',
+    stat = ServiceDRStatus({'message':'You defined service that does not exist in cluster',
                           'wrong-service':'absent-service'})
     assert stat.service in 'absent-service' and stat.message and not stat.is_ok()
 
@@ -472,6 +472,14 @@ def test_sm_poll_service_required_status(mocker, caplog):
         caplog.clear()
         sm_poll_service_required_status("k8s-1", "serv1", "active", sm_dict)
         assert "100 seconds left until timeout" in caplog.text
+
+    # service specific timeout occured
+    sm_dict["k8s-1"]={"services":{
+        "serv1":{"timeout":1}}}
+    with caplog.at_level(logging.INFO):
+        caplog.clear()
+        sm_poll_service_required_status("k8s-1", "serv1", "disable", sm_dict)
+        assert "Timeout expired" in caplog.text
 
     # healthz up
     test_resp={'services':{'serv1':{'healthz':'up', 'mode':'active', 'status':'done'}}}


### PR DESCRIPTION
Sequential polling causes issues.
- Updated polling approach to wait all 3 parameres in requred state: _status, healthz, mode_
- Added more INFO logging during polling