### PR TITLE
[MANOPD-82933] - support tokens from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,11 +805,12 @@ The main configuration file for `sm-client` in a short format looks like the fol
 ---
 sites:
   - name: k8s-1
-    token: <TOKEN>
+    token: "some token"
     site-manager: http://site-manager.k8s-1.example.com/sitemanager
     cacert: <path-to-ca-certificate>
   - name: k8s-2
-    token: <TOKEN>
+    token: 
+      from_env: SOME_SM_TOKEN_ENV
     site-manager: http://site-manager.k8s-2.example.com/sitemanager
     cacert: <path-to-ca-certificate>
 
@@ -821,7 +822,9 @@ sm-client:
 Where:
  - `sites` is the list of Kubernetes clusters.
  - `name` is the short name of a cluster.
- - `token` is the token to have access to `site-manager` in a Kubernetes cluster.
+ - `token` is the token to have access to `site-manager` in a Kubernetes cluster. It can have value with string type (like 
+for `k8s-1` in example above) or contains `from_env` field with environment variable, where token is collected (like for `k8s-2`
+in example above)
  - `cacert` is the path to the CA certificate for `site-manager` with a self-signed certificate.
  - `http_auth` specifies to use a token for `site-manager` authorization.
  - `service_default_timeout` is optional parameter, that specifies default timeout for polling services in seconds. 

--- a/sm-client
+++ b/sm-client
@@ -204,7 +204,21 @@ def init_and_check_config(args) -> bool:
             logging.error("Check configuration file. Some of sites does not have 'site-manager' parameter")
             return False
 
-        site_token = [ i.get("token", "") for i in conf_parsed["sites"] if i ["name"] == site ][0]
+        for i in conf_parsed["sites"]:
+            if i["name"] != site:
+                continue
+            if isinstance(i.get("token", ""), dict):
+                if "from_env" not in i.get("token", {}):
+                    logging.error(f"Wrong token configuration for site {i['name']}: "
+                                  f"use string value or specify from_env parameter")
+                    return False
+                site_token = os.environ.get(i["token"]["from_env"])
+                if site_token is None:
+                    logging.error(f"Wrong token configuration for site {i['name']}: "
+                                  f"specified env {i['token']['from_env']} doesn't exist")
+                    return False
+            else:
+                site_token = i.get("token", "")
         site_cacert = [ i.get("cacert", True) for i in conf_parsed["sites"] if i ["name"] == site ][0]
 
         if site_cacert != True and not os.path.isfile(site_cacert):

--- a/tests/selftest/resources/config_test_with_env_token.yaml
+++ b/tests/selftest/resources/config_test_with_env_token.yaml
@@ -1,0 +1,11 @@
+sites:
+  - name: k8s-1
+    token: XXX
+    site-manager: https://site-manager.k8s-1.netcracker.com/sitemanager
+  - name: k8s-2
+    token:
+      from_env: SM_TEST_TOKEN
+    site-manager: https://site-manager.k8s-2.netcracker.com/sitemanager
+sm-client:
+  http_auth: True
+  service_default_timeout: 400

--- a/tests/selftest/resources/config_test_wrong_with_env_token.yaml
+++ b/tests/selftest/resources/config_test_wrong_with_env_token.yaml
@@ -1,0 +1,11 @@
+sites:
+  - name: k8s-1
+    token: XXX
+    site-manager: https://site-manager.k8s-1.netcracker.com/sitemanager
+  - name: k8s-2
+    token:
+      from_env_wrong: SM_TEST_TOKEN
+    site-manager: https://site-manager.k8s-2.netcracker.com/sitemanager
+sm-client:
+  http_auth: True
+  service_default_timeout: 400


### PR DESCRIPTION
### Support selection environments, where needed SM tokens are collected.

Example of config.yaml with both variants of configuration (SM_TOKEN env should contain token for site-2):
```yaml
sites:
  - name: site-1
    site-manager: <site-1-url>
    token: "<token for site-1>"
  - name: site-2
    site-manager: <site-2-url>
    token: 
        from_env: SM_TOKEN
sm-client:
  http_auth: True
```