### PR TITLE
[MANOPD-83120] filter secrets by token in get_token func

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -191,7 +191,7 @@ def get_token(api_watch=False):
                 if event['object'].metadata.name == "sm-auth-sa":
                     if event['type'] in ["ADDED", "MODIFIED"]:
                         try:
-                            secret_name = [s for s in event['object'].secrets][0].name
+                            secret_name = [s for s in event['object'].secrets if 'token' in s.name][0].name
                         except: # hit here when secret for appropriate  SA is not ready yet
                             continue
 


### PR DESCRIPTION
If SA contains more that one secret, `get_token` func can fail, if wrong token was first.
Added filtration for secrets there like in first getting SA secret.