### PR TITLE
[PDSDNREQ-6506] Ingress Site-Manager ignoring because of error while validating ingress class

### DIFF
--- a/charts/site-manager/templates/ingress.yaml
+++ b/charts/site-manager/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   labels:
     app: {{ .Chart.Name }}


### PR DESCRIPTION
### Description
* When installing and updating kubernetes to version 1.25 with nginx version 1.4.0. With site-manager installed on the cluster. Ingress site-manager will become unavailable with the error "Ignoring ingress because of error while validating ingress class ingress="site-manager/site-manager" error="ingress does not contain a valid IngressClass" on Ingress-nginx-controller
* By default, Ingress-nginx-controller supports ciphers only from its own embedded list.
### Solution
* The list of supportable ciphers may be configured by annotation of the particular ingress
* Template ingress site-manager has been updated for installation using helm
