### PR TITLE
[MANOPD-84965] Service without status in SiteManager when tls enabled - SSL certificate verify failed

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -89,7 +89,7 @@ def send_post(url, mode, no_wait):
     return dict.fromkeys(['fatal'], True)
 
 
-def io_make_http_json_request(url="", token="", verify=True, http_body:dict=None, retry=3, use_auth=FRONT_HTTP_AUTH) -> Tuple[bool, Dict, int]:
+def io_make_http_json_request(url="", token="", verify=SM_CACERT, http_body:dict=None, retry=3, use_auth=FRONT_HTTP_AUTH) -> Tuple[bool, Dict, int]:
     """ Sends GET/POST request to service
     @param string url: the URL to service operator
     @param token: Bearer token


### PR DESCRIPTION
### Description
When the service is deployed with tls enabled and using self signed certificate, the site-manager will give an error about SSL certificate verify failed

### Solution
Fix io_make_http_json_request to use  `env.SM_CACERT` that skips TLS verification