### PR TITLE
[MANOPD-85401] - except ValueError for ServiceDRStatus

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -520,7 +520,12 @@ def run(services:[] = None, cmd="", site=""):
                 response, _, return_code=sm_process_service(site, serv, "status")
                 if not sm_dict[site]['services'].get(serv):
                     sm_dict[site]['services'][serv]={}
-                sm_dict[site]['services'][serv]['status']=ServiceDRStatus(response) if return_code else False
+                try:
+                    sm_dict[site]['services'][serv]['status']=ServiceDRStatus(response) if return_code else False
+                except ValueError:
+                    logging.error(f"Site:{site} service:{serv}, can't recognise status for service, status code: "
+                                  f"{return_code}: {response}")
+                    sm_dict[site]['services'][serv]['status'] = False
 
             for site_i in sm_dict.get_available_sites():
                 thread=threading.Thread(target=run_in_thread, args=(site_i, serv, sm_dict))


### PR DESCRIPTION
If SM can't answer normally for service status request (e.g return 500 status code), we throw ValueError in ServiceDRStatus.   
For this reason we should handle such exception, when we process status request.  

### Common test case
Something went wrong during getting SM structures. In that case SM returns 500 status code and following message on service status request:
`{"message":  "Can not get sitemanager structures"}`
We throw an ValueError exception in ServiceDRStatus on this: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/./sm-client", line 523, in run_in_thread
    sm_dict[site]['services'][serv]['status']=ServiceDRStatus(response) if return_code else False
  File "/opt/./sm-client", line 260, in __init__
    raise ValueError("Missing service name")
ValueError: Missing service name
```