### PR TITLE
[MANOPD-86910] - Fix cr-conversation after lint PR

### DIFF
--- a/site-manager.py
+++ b/site-manager.py
@@ -200,7 +200,7 @@ def cr_convert():
 
     spec = request.json["request"]["objects"]
     modified_spec = copy.deepcopy(spec)
-    for i in enumerate(modified_spec):
+    for i, _ in enumerate(modified_spec):
         # v1 -> v2, v3 conversion
         if modified_spec[i]["apiVersion"] == "netcracker.com/v1":
             if "module" not in modified_spec[i]["spec"]["sitemanager"]:


### PR DESCRIPTION
After #98  server's cr conversation was broken with exception:
```
[2023-04-03 07:44:27 +0000] [8] [ERROR] Error handling request /convert?timeout=30s
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 55, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/ggevent.py", line 127, in handle_request
    super().handle_request(listener_name, req, sock, addr)
  File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 108, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/app/site-manager.py", line 206, in cr_convert
    if modified_spec[i]["apiVersion"] == "netcracker.com/v1":
TypeError: list indices must be integers or slices, not tuple
```
This fix resolves this exception.