### PR TITLE
[MANOPD-87044] - fix storage version

### DIFF
--- a/manifests/crd-sitemanager.yaml
+++ b/manifests/crd-sitemanager.yaml
@@ -13,7 +13,7 @@ spec:
   versions:
   - name: v3
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
     schema:
@@ -85,7 +85,7 @@ spec:
         type: object
   - name: v2
     served: true
-    storage: false
+    storage: true
     deprecated: true
     deprecationWarning: >-
       netcracker.com/v2 SiteManager is deprecated; use v3 and see actual


### PR DESCRIPTION
# Problem
If service is deployed firstly, when it's CR dependency hasn't existed yet, it's CR will be converted to v3 version with unknown dependency and such version will be stored in etcd.
As result, namespace for dependency won't be added whether the dependency exists in cloud or not. 

# Solution
Downgrade storage version to v2 to save CR without adding namespaces for dependencies (they will be added during v3 convertation by call).