### PR TITLE
[PDSDNREQ-6974] site-manager certificate renewal procedure part.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,8 +1236,12 @@ To renew a certificate:
     ```
     $ kubectl -n site-manager create secret tls sm-certs --cert site-manager-tls.crt --key site-manager-tls.key
     ```
-4. Update `config.yml` (Token and path cacert).
-5. Restart pod `site-manager`
+4. Restart pod `site-manager`
+    ```
+    $ kubectl rollout restart deployment site-manager -n site-manager
+    ```
+5. Update `config.yml` (Token and path cacert).
+
  
 ### Installation 
  


### PR DESCRIPTION
Description

It is necessary to reproduce the certificate renewal procedure for site-manager
A restart of the site-manager pod is required to update the certificates required for operation

Solution

The documentation has been updated and added new requirements for the renewal procedure.