### PR TITLE
[CPDEV-89451] Warning for deprecated annotation for ingress "kubernetes.io/ingress.class" 

### DIFF
--- a/charts/site-manager/templates/ingress.yaml
+++ b/charts/site-manager/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/backend-protocol: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled }}
   labels:
     app: {{ .Chart.Name }}


### PR DESCRIPTION
# Issue
Starting from k8s v1.27.1, when we install site-magaer, during installation we are getting to see a waring message related to annotations on ingress as below -
```
W0613 18:45:44.686462   47044 warnings.go:67] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
NAME: site-manager
LAST DEPLOYED: Tue Jun 13 18:45:23 2023
NAMESPACE: site-manager
STATUS: deployed
REVISION: 1
...
```

This messages is getting displayed as `kubernetes.io/ingress.class` annotation is officially [deprecated](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation)

# Solution

To remove this deprecated annotation from site-manager ingress.
https://git.netcracker.com/PROD.Platform.HA/site-manager/-/blob/0.14.0/charts/site-manager/templates/ingress.yaml#L8

# Test Cases
1. k8s v1.26.4 with exiting annotation
```
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get ing -A
NAMESPACE              NAME                   CLASS    HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx    dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   50m
site-manager           site-manager           <none>   site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   31m
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-5bf79dfb69-rwzzr   2/2     Running   0          34m

NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.140.34   <none>        443/TCP,442/TCP   34m

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           34m

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-5bf79dfb69   1         1         1       34m
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-5944f9967d-gldxr   1/1     Running   0          30m

NAME               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.182.135   <none>        80/TCP    30m

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           30m

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-5944f9967d   1         1         1       30m
```
2. k8s v1.26.4 after removing annotation 
```
root@k8s-prpa-aio2:~/DRNavigator-main# k get ing -A
NAMESPACE              NAME                   CLASS   HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx   dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   2h
site-manager           site-manager           nginx   site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   26s
root@k8s-prpa-aio2:~/DRNavigator-main# kubectl get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-5bf79dfb69-vlcph   2/2     Running   0          64s

NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.120.43   <none>        443/TCP,442/TCP   64s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           64s

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-5bf79dfb69   1         1         1       64s
root@k8s-prpa-aio2:~/DRNavigator-main#
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-5944f9967d-vt9ql   1/1     Running   0          80s

NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.150.55   <none>        80/TCP    81s

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           81s

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-5944f9967d   1         1         1       80s
```
3. k8s v1.26.7 with exiting annotation
```
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get ing -A
NAMESPACE              NAME                   CLASS    HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx    dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   24h
site-manager           site-manager           <none>   site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   31m
sm-dummy               test-svc               nginx    test-svc.k8s-prpa-aio2.k8s.sdntest.netcracker.com       192.168.234.19   80        27m
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-5bf79dfb69-rwzzr   2/2     Running   0          34m

NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.134.210   <none>        443/TCP,442/TCP   34m

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           34m

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-5bf79dfb69   1         1         1       34m
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-5944f9967d-gldxr   1/1     Running   0          30m

NAME               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.107.195   <none>        80/TCP    30m

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           30m

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-5944f9967d   1         1         1       30m
```
4. k8s v1.27.1 after removing annotation 
```
root@k8s-prpa-aio2:~/DRNavigator-main# k get ing -A
NAMESPACE              NAME                   CLASS   HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx   dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   28h
site-manager           site-manager           nginx   site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   26s
root@k8s-prpa-aio2:~/DRNavigator-main# kubectl get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-5bf79dfb69-vlcph   2/2     Running   0          64s

NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.150.66   <none>        443/TCP,442/TCP   64s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           64s

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-5bf79dfb69   1         1         1       64s
root@k8s-prpa-aio2:~/DRNavigator-main#
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# kubectl get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-5944f9967d-vt9ql   1/1     Running   0          80s

NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.130.22   <none>        80/TCP    81s

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           81s

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-5944f9967d   1         1         1       80s
```
5. k8s v1.27.1 with exiting annotation
```
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get ing -A
NAMESPACE              NAME                   CLASS   HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx   dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   28h
site-manager           site-manager           <none>  site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   71s
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-848f876669-9vm85   2/2     Running   0          81s

NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.75.237   <none>        443/TCP,442/TCP   81s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           81s

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-848f876669   1         1         1       81s
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-6559767f6d-nwvvk   1/1     Running   0          32s

NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.82.127   <none>        80/TCP    32s

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           32s

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-6559767f6d   1         1         1       32s
```
6. k8s v1.26.7 after removing annotation 
```
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get ing -A
NAMESPACE              NAME                   CLASS   HOSTS                                                   ADDRESS          PORTS     AGE
kubernetes-dashboard   kubernetes-dashboard   nginx   dashboard.k8s-prpa-aio2.k8s.sdntest.netcracker.com      192.168.234.19   80, 443   28h
site-manager           site-manager           nginx   site-manager.k8s-prpa-aio2.k8s.sdntest.netcracker.com   192.168.234.19   80, 443   71s
sm-dummy               test-svc               nginx   test-svc.k8s-prpa-aio2.k8s.sdntest.netcracker.com                        80        11s
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get all -n site-manager
NAME                                READY   STATUS    RESTARTS   AGE
pod/site-manager-848f876669-9vm85   2/2     Running   0          81s

NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
service/site-manager   ClusterIP   172.30.102.150   <none>        443/TCP,442/TCP   81s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/site-manager   1/1     1            1           81s

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/site-manager-848f876669   1         1         1       81s
root@k8s-prpa-aio2:~/DRNavigator-main/tests/sm-dummy# k get all -n sm-dummy
NAME                            READY   STATUS    RESTARTS   AGE
pod/test-svc-6559767f6d-nwvvk   1/1     Running   0          32s

NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/test-svc   ClusterIP   172.30.88.179   <none>        80/TCP    32s

NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test-svc   1/1     1            1           32s

NAME                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/test-svc-6559767f6d   1         1         1       32s
```