### PR TITLE
[CPDEV-91582] - use post request timeout for CRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,19 @@ Before the installation, ensure that you have enough resources for DRNavigator.
 For one pod, it is recommended to use 100m CPU and 80Mi memory limits per worker and by default, DRNavigator uses 2 workers.
 You can override the worker count and cpu/memory limits using helm environments.
 
+Default quotas:
+
+|                            | CPU Limit         | Memory Limit          |
+|----------------------------|-------------------|-----------------------|
+| site-manager               | 200m              | 160Mi                 |
+| site-manager-cr-controller | 300m              | 150Mi                 |
+| **Total**                  | 500m              | 310Mi                 |
+
+Needed quotas depends on the number of services, for this reason, if you have problems with services processing (typically, with timeouts),
+you can do one of following solutions:
+* Increase timeouts for site-manager and sm-client;
+* Increase quotas for site-manager;
+
 ### Prerequisites
  
 Prepare a Kubernetes cluster to work with DRNavigator.

--- a/charts/site-manager/templates/deployment.yaml
+++ b/charts/site-manager/templates/deployment.yaml
@@ -110,8 +110,8 @@ spec:
             value: "{{ .Values.env.SM_PLURAL }}"
           - name: SM_VERSION
             value: "{{ .Values.env.SM_VERSION }}"
-          - name: SM_GET_REQUEST_TIMEOUT
-            value: "{{ .Values.env.SM_GET_REQUEST_TIMEOUT }}"
+          - name: SM_POST_REQUEST_TIMEOUT
+            value: "{{ .Values.env.SM_POST_REQUEST_TIMEOUT }}"
         ports:
           - containerPort: 8442
             protocol: TCP

--- a/site-manager-cr-controller/config/config.go
+++ b/site-manager-cr-controller/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	CRPrural  string `envconfig:"SM_PRURAL" default:"sitemanagers"`
 	CRVersion string `envconfig:"SM_VERSION" default:"v3"`
 
-	GetRequestTimeout int64 `envconfig:"SM_GET_REQUEST_TIMEOUT" default:"10"`
+	PostRequestTimeout int64 `envconfig:"SM_POST_REQUEST_TIMEOUT" default:"30"`
 }
 
 var EnvConfig Config

--- a/site-manager-cr-controller/pkg/client/cr_client.go
+++ b/site-manager-cr-controller/pkg/client/cr_client.go
@@ -48,7 +48,7 @@ func NewCRClient() (*CRClient, error) {
 			return nil, fmt.Errorf("error config for kubernetes client: %s", err)
 		}
 	}
-	config.Timeout = time.Duration(envconfig.EnvConfig.GetRequestTimeout) * time.Second
+	config.Timeout = time.Duration(envconfig.EnvConfig.PostRequestTimeout) * time.Second
 	client, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("error creating kube client for CR: %s", err)

--- a/site-manager.py
+++ b/site-manager.py
@@ -72,7 +72,7 @@ def get_sitemanagers_dict(api_version=server_utils.SM_VERSION):
         response = client.CustomObjectsApi().list_cluster_custom_object(group=server_utils.SM_GROUP,
                                                                         version=api_version,
                                                                         plural=server_utils.SM_PLURAL,
-                                                                        _request_timeout=utils.SM_GET_REQUEST_TIMEOUT)
+                                                                        _request_timeout=utils.SM_POST_REQUEST_TIMEOUT)
 
     except ApiException as e:
         if e.status == 404:


### PR DESCRIPTION
* Used POST request timeout for CR requests. Although, it's GET request to kubeapi, but inside it follows POST conversation request;
* Added table with resource quotas and in that cases they can be increased;