### PR TITLE
[CPDEV-99138] - add runAsUser if it's not defined and it's not openshift

### DIFF
--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -30,6 +30,14 @@ IP addresses used to generate SSL certificate with "Subject Alternative Name" fi
   {{- $ipAddresses | toYaml -}}
 {{- end -}}
 
+{{- define "securityContext" -}}
+    securityContext:
+        {{- .Values.securityContext | toYaml | nindent 8  }}
+        {{- if and (not .Values.securityContext.runAsUser) (not (.Capabilities.APIVersions.Has "apps.openshift.io/v1")) }}
+        runAsUser: 10001
+        {{- end -}}
+{{- end -}}
+
 {{- define "paas-geo-monitor.port" -}}
   {{- print ( default 8080 .Values.paasGeoMonitor.config.port ) -}}
 {{- end -}}

--- a/charts/site-manager/templates/deployment.yaml
+++ b/charts/site-manager/templates/deployment.yaml
@@ -19,10 +19,7 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       automountServiceAccountToken: false
-      {{- with .Values.securityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{ include  "securityContext" . }}
       containers:
       - name: {{ .Chart.Name }}
         {{- with .Values.containerSecurityContext }}

--- a/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
+++ b/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
@@ -18,10 +18,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- with .Values.securityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{ include  "securityContext" . }}
       containers:
       - name: paas-geo-monitor
         {{- with .Values.containerSecurityContext }}

--- a/charts/site-manager/values.yaml
+++ b/charts/site-manager/values.yaml
@@ -26,7 +26,6 @@ env:
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
-  runAsUser: 10001
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
Apply `runAsUser=10001` security context only for kubernetes and if it's not overridden by user. 