### PR TITLE
fix docker-compose

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -47,7 +47,7 @@ jobs:
           ref: ${{ matrix.sm-version }}
           clean: false
       - name: Run docker compose
-        run: docker-compose -f ${{ env.benchmark_dir }}/docker-compose.yaml up --detach
+        run: docker compose -f ${{ env.benchmark_dir }}/docker-compose.yaml up --detach
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -62,10 +62,10 @@ jobs:
           retention-days: 1
       - name: Collect logs from docker-compose
         if: ${{ !cancelled() }}
-        run: docker-compose -f ${{ env.benchmark_dir }}/docker-compose.yaml logs > docker-compose.log
+        run: docker compose -f ${{ env.benchmark_dir }}/docker-compose.yaml logs > docker-compose.log
       - name: Down docker compose
         if: ${{ !cancelled() }}
-        run: docker-compose -f ${{ env.benchmark_dir }}/docker-compose.yaml down
+        run: docker compose -f ${{ env.benchmark_dir }}/docker-compose.yaml down
       - name: Collect artifacts logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Get python version
         run: python --version
       - name: Get Docker-compose version
-        run: docker-compose version
+        run: docker compose version
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ docker build -t sm-dummy --no-cache tests/sm-dummy
 2. Run docker-compose:
 
 ```bash
-docker-compose -f ./tests/docker-compose/docker-compose.yaml up --detach
+docker compose -f ./tests/docker-compose/docker-compose.yaml up --detach
 ```
 
 3. Run `sm-client` with `./tests/docker-compose/sm-client-config.yaml` as sm-client config. For-example, `status`:
@@ -69,12 +69,12 @@ curl -H "Authorization: Bearer 12345" localhost:9010/sitemanager
 
 5. Open docker-compose logs to see site-manager or sm-dummy logs:
 ```bash
-docker-compose -f ./tests/docker-compose/docker-compose.yaml logs
+docker compose -f ./tests/docker-compose/docker-compose.yaml logs
 ```
 
 6. Stop docker-compose, if you want to rebuild site-manager or sm-dummy, or return it to initial state:
 ```bash
-docker-compose -f ./tests/docker-compose/docker-compose.yaml down
+docker compose -f ./tests/docker-compose/docker-compose.yaml down
 ```
 
 # Site-manager selftests

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,18 +62,18 @@ def prepare_configs(request, tmpdir_factory, build_images):
 def prepare_docker_compose(config_dir):
     # Docker-compose up
     logging.info("Docker compose up")
-    os.system(f"docker-compose -f {os.path.join(config_dir, 'docker-compose.yaml')} up --detach")
+    os.system(f"docker compose -f {os.path.join(config_dir, 'docker-compose.yaml')} up --detach")
 
     # Run tests
     yield
 
     # Collect logs from docker-compose
-    os.system(f"docker-compose -f {os.path.join(config_dir, 'docker-compose.yaml')} logs > "
+    os.system(f"docker compose -f {os.path.join(config_dir, 'docker-compose.yaml')} logs > "
               f"{os.path.join(config_dir, 'docker_logs.log')}")
 
     # Docker-compose down
     logging.info("Docker compose down")
-    os.system(f"docker-compose -f {os.path.join(config_dir, 'docker-compose.yaml')} down")
+    os.system(f"docker compose -f {os.path.join(config_dir, 'docker-compose.yaml')} down")
 
 
 @pytest.fixture(scope='class', name='wait_services_until_healthy')

--- a/tests/integration/tests/unavailable_service_test.py
+++ b/tests/integration/tests/unavailable_service_test.py
@@ -48,7 +48,7 @@ class UnavailableServiceTestCase:
 
     def test_init_statuses(self, config_dir, capfd):
         logging.info("Pause service to emulate not working")
-        os.system(f"docker-compose -f {os.path.join(config_dir, 'docker-compose.yaml')} pause serviceB-site-2")
+        os.system(f"docker compose -f {os.path.join(config_dir, 'docker-compose.yaml')} pause serviceB-site-2")
 
         logging.info("TEST INIT STATUSES")
         check_statuses(capfd, template_env, lambda site, service: {


### PR DESCRIPTION
## Description

`docker-compose` is deprecated and looks like excluded from `ubuntu-latest` runner. So pipelines are failed with `command not found` error, e.g.: https://github.com/Netcracker/DRNavigator/actions/runs/10216727689/job/28268871022
From official docker documentation: https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

## Solution

All `docker-compose` command are moved to `docker compose` in pipelines / code / documentation.
**Note**: does not affect site-manager itself, needed only for CI tests.