### PR TITLE
add info, how sm-auth-sa token with duration can be generated

### DIFF
--- a/documentation/public/installation.md
+++ b/documentation/public/installation.md
@@ -359,12 +359,12 @@ peers.
 
 Where,
 
-- `<BEARER TOKEN>` should be taken from the `sm-auth-sa` service-account. It can be endless token from `sm-auth-sa-token` 
-secret, that can be obtained with following command:
+- `<BEARER TOKEN>` should be taken from the `sm-auth-sa` service-account. It might be specified in two ways
+  - endless token from `sm-auth-sa-token` secret, that can be obtained with following command:
   ```shell
   kubectl get secret sm-auth-sa-token -n site-manager -o yaml | grep token: | cut -d ' ' -f4 | base64 --decode
   ```
-  Or you can always generate temporary token with specified duration using command:
+  - temporary token generated with specified duration using command:
   ```shell
   kubectl create token -n site-manager sm-auth-sa --duration=1h
   ```


### PR DESCRIPTION
* Add information. how `sm-auth-sa` token can be generated with duration.