### PR TITLE
Support for Restricted Environment

### DIFF
--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -43,13 +43,14 @@ IP addresses used to generate SSL certificate with "Subject Alternative Name" fi
 {{- end -}}
 
 {{/*
-Checks if the environment is restricted (from .Values.INFRA_RESTRICTED_ENVIRONMENT).
-And render ClusterAdminEntities templates (cluster-role & cluster-role-biding) only if environment is not restricted. 
+Returns true if RBAC should be created.
+If INFRA_RESTRICTED_ENVIRONMENT is true => return false
+Else => return createClusterAdminEntities (default false)
 */}}
-{{- define "sitemanager.shouldCreateClusterAdminEntities" -}}
-  {{- if or (not (hasKey .Values "INFRA_RESTRICTED_ENVIRONMENT")) (not .Values.INFRA_RESTRICTED_ENVIRONMENT) -}}
-    {{- .Values.createClusterAdminEntities | default false | toYaml -}}
-  {{- else -}}
+{{- define "site-manager.shouldCreateClusterAdminEntities" -}}
+  {{- if and (hasKey .Values "INFRA_RESTRICTED_ENVIRONMENT") .Values.INFRA_RESTRICTED_ENVIRONMENT }}
     false
-  {{- end -}}
-{{- end -}}
+  {{- else }}
+    {{- .Values.createClusterAdminEntities | default false }}
+  {{- end }}
+{{- end }}

--- a/charts/site-manager/templates/cluster-role-binding.yaml
+++ b/charts/site-manager/templates/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{ if (include "sitemanager.shouldCreateClusterAdminEntities" .) | fromYaml }}
+{{- if eq (include "site-manager.shouldCreateClusterAdminEntities" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +11,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
-{{ end }}
+{{- end }}

--- a/charts/site-manager/templates/cluster-role.yaml
+++ b/charts/site-manager/templates/cluster-role.yaml
@@ -1,4 +1,5 @@
-{{ if (include "sitemanager.shouldCreateClusterAdminEntities" .) | fromYaml }}
+# shouldCreateClusterAdminEntities = {{ include "site-manager.shouldCreateClusterAdminEntities" . | quote }}
+{{- if eq (include "site-manager.shouldCreateClusterAdminEntities" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -25,4 +26,4 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-{{ end }}
+{{- end }}


### PR DESCRIPTION
## Description
* Currently, if we try to deploy site-manager using helm charts in a restricted environment where it requires cluster admin privileges to create RBAC entities, it is impossible to deploy.

## Solution
* Added a new variable "_shouldCreateClusterAdminEntities_" through helper which will check for "_INFRA_RESTRICTED_ENVIRONMENT_" variable in valuse and skip the creation of RBAC entities if it's value to be found as "_**true**_".
If "_INFRA_RESTRICTED_ENVIRONMENT_" is set to false or absent is values then it will honor exiting variable "_createClusterAdminEntities_" to decide creation of RBAC entities.