### PR TITLE
Service order printing improvements

### DIFF
--- a/sm-client
+++ b/sm-client
@@ -85,9 +85,9 @@ def print_service_order(sm_dict: SMClusterState, cmd, site):
                 if cmd in settings.dr_processing_cmd:
                     if flow_cmds:
                         actual_site = site
-                        if flow_cmds[0] == "standby" and cmd == "move":
-                            actual_site = settings.sm_conf.get_opposite_site(site) 
-                        if flow_cmds[0] == "active" and cmd == "stop":
+                        is_standby_during_move = flow_cmds[0] == "standby" and cmd == "move"
+                        is_active_during_stop = flow_cmds[0] == "active" and cmd == "stop"
+                        if is_standby_during_move or is_active_during_stop:
                             actual_site = settings.sm_conf.get_opposite_site(site)
                         logging.debug(f"{svc}: {flow_cmds[0]} on {actual_site}")
                     else:


### PR DESCRIPTION
### Problem
Need to improve services order printing. Currently it does not prints details for custom modules/services. This is how it looks currently (move site-2), there is no information on custom service operation:
```bash
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(60): Service order by dependency:
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(62): --------------------
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(64): customService
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(69): ------ Stage 1 -------
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(74): serviceA ( -> active on site-2 -> standby on site-1 )
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(74): serviceC ( -> standby on site-1 -> active on site-2 )
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(69): ------ Stage 2 -------
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(74): serviceB ( -> standby on site-1 -> active on site-2 )
2025-06-30 10:59:10,516 [DEBUG] sm-client.print_service_order(76): Done. ----------------
```

### Solution
* order no longer prints for status/list commands, because it does not make sense for these commands, they have no specific order
* improved output a bit, to make it more consistent and lest cluttered
* order now prints operation details for custom services, for example (move site-2)
```bash
2025-06-30 11:01:15,679 [DEBUG] sm-client.print_service_order(63): Service order by dependency:
2025-06-30 11:01:15,679 [DEBUG] sm-client.print_service_order(78): ------ Stage 1 -------
2025-06-30 11:01:15,679 [DEBUG] sm-client.print_service_order(92): customService: standby on site-1
2025-06-30 11:01:15,679 [DEBUG] sm-client.print_service_order(78): ------ Stage 2 -------
2025-06-30 11:01:15,679 [DEBUG] sm-client.print_service_order(96): serviceA: active on site-2 -> standby on site-1
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(96): serviceC: standby on site-1 -> active on site-2
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(78): ------ Stage 3 -------
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(96): serviceB: standby on site-1 -> active on site-2
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(78): ------ Stage 4 -------
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(92): customService: active on site-2
2025-06-30 11:01:15,680 [DEBUG] sm-client.print_service_order(102): ------ Done ------
```