### PR TITLE
Migrate on K8s Gateway API

### DIFF
--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -8,7 +8,6 @@ Return the appropriate host for ingress.
     {{- printf "site-manager-%s.%s" .Release.Namespace .Values.CLOUD_PUBLIC_HOST }}
   {{- end -}}
 {{- end -}}
-
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
@@ -50,4 +49,3 @@ IP addresses used to generate SSL certificate with "Subject Alternative Name" fi
 {{- define "paas-geo-monitor.port" -}}
   {{- print ( default 8080 .Values.paasGeoMonitor.config.port ) -}}
 {{- end -}}
-

--- a/charts/site-manager/templates/backendtlspolicy.yaml
+++ b/charts/site-manager/templates/backendtlspolicy.yaml
@@ -1,0 +1,23 @@
+{{- $hasHttpRouteApi := .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+{{- $isKubernetes := eq .Values.PAAS_PLATFORM "KUBERNETES" -}}
+{{- $backendTlsHostname := include "site-manager.ingress.host" . -}}
+{{- if and $hasHttpRouteApi $isKubernetes .Values.tls.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Chart.Name }}-backend-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Chart.Name }}
+  validation:
+    hostname: {{ $backendTlsHostname | quote }}
+    caCertificateRefs:
+      - group: ""
+        kind: Secret
+        name: sm-certs
+{{- end }}

--- a/charts/site-manager/templates/httproute.yaml
+++ b/charts/site-manager/templates/httproute.yaml
@@ -1,0 +1,33 @@
+{{- $hasHttpRouteApi := .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+{{- $isKubernetes := eq .Values.PAAS_PLATFORM "KUBERNETES" -}}
+{{- if and $hasHttpRouteApi $isKubernetes -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.httpRoute.gatewayName | quote }}
+      namespace: {{ .Values.httpRoute.gatewayNamespace | quote }}
+  {{- if .Values.ingress.name }}
+  hostnames:
+    - {{ .Values.ingress.name | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Chart.Name }}
+          port: 443
+          weight: 1
+{{- end }}

--- a/charts/site-manager/templates/httproute.yaml
+++ b/charts/site-manager/templates/httproute.yaml
@@ -15,10 +15,8 @@ spec:
       kind: Gateway
       name: {{ .Values.httpRoute.gatewayName | quote }}
       namespace: {{ .Values.httpRoute.gatewayNamespace | quote }}
-  {{- if .Values.ingress.name }}
   hostnames:
-    - {{ .Values.ingress.name | quote }}
-  {{- end }}
+    - {{ include "site-manager.ingress.host" . | quote }}
   rules:
     - matches:
         - path:

--- a/charts/site-manager/templates/ingress.yaml
+++ b/charts/site-manager/templates/ingress.yaml
@@ -1,9 +1,13 @@
+{{- if .Values.ingress.create }}
 apiVersion: {{ include "site-manager.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
+    # Prevent gateway-api-converter from auto-converting this legacy Ingress
+    # when Gateway API resources (HTTPRoute, etc) are managed by chart.
+    gateway-api-converter.netcracker.com/ignore: "true"
     {{- if .Values.tls.enabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- if .Values.tls.defaultIngressTls }}
@@ -44,3 +48,4 @@ spec:
             port:
               number: 443
   {{- end }}
+{{- end }}

--- a/charts/site-manager/values.yaml
+++ b/charts/site-manager/values.yaml
@@ -56,6 +56,14 @@ ingress:
   name: ""
   className: ""
 
+# Gateway API (HTTPRoute) configuration.
+# Resources are created only when:
+# 1) gateway.networking.k8s.io/v1 CRDs are present
+# 2) PAAS_PLATFORM=KUBERNETES
+httpRoute:
+  gatewayName: default-external-gateway
+  gatewayNamespace: envoy-gateway
+
 limits:
   cpu: "20m"
   memory: "100Mi"


### PR DESCRIPTION
- Added `charts/site-manager/templates/httproute.yaml` (conditional creation).
- Added `charts/site-manager/templates/backendtlspolicy.yaml` for HTTPS backend verification.
- Updated `charts/site-manager/templates/ingress.yaml`:
  - added `gateway-api-converter.netcracker.com/ignore: "true"`,
  - aligned host handling to shared helper.
- Updated `charts/site-manager/templates/_helpers.tpl`:
  - added `site-manager.ingress.host` helper (`ingress.name` or `site-manager-<ns>.<CLOUD_PUBLIC_HOST>`),
  - reused it in certificate DNS names.
- Updated `charts/site-manager/values.yaml`:
  - added `httpRoute.gatewayName` and `httpRoute.gatewayNamespace`,
  - added `CLOUD_PUBLIC_HOST` default.

Gateway API resources are created only when:
- `gateway.networking.k8s.io/v1` CRD is present
- `PAAS_PLATFORM=KUBERNETES`

`BackendTLSPolicy` is additionally created only when:
- `tls.enabled=true`

