### PR TITLE
security hardening

### DIFF
--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -41,8 +41,9 @@ IP addresses used to generate SSL certificate with "Subject Alternative Name" fi
 {{- define "securityContext" -}}
     securityContext:
         {{- .Values.securityContext | toYaml | nindent 8  }}
-        {{- if and (not .Values.securityContext.runAsUser) (not (.Capabilities.APIVersions.Has "apps.openshift.io/v1")) }}
-        runAsUser: 10001
+        {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+        runAsUser: 1001
+        runAsGroup: 1001
         {{- end -}}
 {{- end -}}
 

--- a/charts/site-manager/templates/deployment.yaml
+++ b/charts/site-manager/templates/deployment.yaml
@@ -22,10 +22,19 @@ spec:
       {{ include  "securityContext" . }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
@@ -78,6 +87,8 @@ spec:
           - mountPath: /rest-api
             name: rest-api-token
             readOnly: true
+          - mountPath: /tmp
+            name: tmp
         resources:
           limits:
             cpu: "{{ .Values.limits.cpu }}"
@@ -107,6 +118,9 @@ spec:
         terminationMessagePath: /dev/termination-log
         imagePullPolicy: {{ .Values.image.pullPolicy }}
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
         - name: sm-certs
           secret:
             secretName: sm-certs

--- a/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
+++ b/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
@@ -21,10 +21,19 @@ spec:
       {{ include  "securityContext" . }}
       containers:
       - name: paas-geo-monitor
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ .Values.paasGeoMonitor.image}}
         imagePullPolicy: Always
         args:
@@ -57,6 +66,8 @@ spec:
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: serviceaccount-token
             readOnly: true
+          - mountPath: /tmp
+            name: tmp
         resources:
           limits:
               cpu: "20m"
@@ -85,6 +96,9 @@ spec:
           successThreshold: 1
           failureThreshold: 5
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
         - name: config
           configMap:
             name: paas-geo-monitor-cfg

--- a/charts/site-manager/values.yaml
+++ b/charts/site-manager/values.yaml
@@ -31,14 +31,6 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container Security Context to be set on the controller component container
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
-  readOnlyRootFilesystem: true
 
 serviceAccount:
   create: true

--- a/tests/docker-compose/docker-compose.yaml
+++ b/tests/docker-compose/docker-compose.yaml
@@ -12,9 +12,13 @@ services:
     image: sm-dummy
     container_name: serviceA-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
       - SMA_DEBUG=True
       - SMA_INIT_MODE=active
+      - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -25,9 +29,13 @@ services:
     image: sm-dummy
     container_name: serviceB-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -38,9 +46,13 @@ services:
     image: sm-dummy
     container_name: serviceC-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -51,9 +63,13 @@ services:
     image: sm-dummy
     container_name: custom-service-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -66,11 +82,14 @@ services:
     image: site-manager
     container_name: site-manager-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - ./site-manager-config.yaml:/val/config.yaml
     command:
       - "--bind=0.0.0.0:8080"
-    environment: 
+    environment:
       - SM_CONFIG_FILE=/val/config.yaml
       - SM_DEBUG=True
       - FRONT_HTTP_AUTH=True
@@ -88,23 +107,31 @@ services:
     image: sm-dummy
     container_name: serviceA-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
       - SMA_DEBUG=True
       - SMA_INIT_MODE=standby
+      - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
       - "9005:8080"
     networks:
       - cluster-2
-         
+
   serviceB-2:
     image: sm-dummy
     container_name: serviceB-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -115,9 +142,13 @@ services:
     image: sm-dummy
     container_name: serviceC-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -128,9 +159,13 @@ services:
     image: sm-dummy
     container_name: custom-service-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -143,11 +178,14 @@ services:
     image: site-manager
     container_name: site-manager-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - ./site-manager-config-2.yaml:/val/config.yaml
     command:
       - "--bind=0.0.0.0:8080"
-    environment: 
+    environment:
       - SM_CONFIG_FILE=/val/config.yaml
       - SM_DEBUG=True
       - FRONT_HTTP_AUTH=True

--- a/tests/sm-dummy/charts/sm-dummy/templates/deployment.yaml
+++ b/tests/sm-dummy/charts/sm-dummy/templates/deployment.yaml
@@ -20,13 +20,26 @@ spec:
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+        {{- if eq (default "" $.Values.PAAS_PLATFORM) "KUBERNETES" }}
+        runAsUser: 1001
+        runAsGroup: 1001
+        {{- end }}
       {{- end }}
       containers:
       - name: sm-dummy
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" $.Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ .Values.image }}
         env:
           - name: SMA_TIMEOUT
@@ -55,6 +68,11 @@ spec:
           - name: SMA_CUSTOM_AUDIENCE
             value: '{{ .Values.env.SMA_CUSTOM_AUDIENCE }}'
             {{- end }}
+          - name: PYTHONDONTWRITEBYTECODE
+            value: "1"
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
         ports:
         - containerPort: 8080
           protocol: TCP
@@ -83,3 +101,7 @@ spec:
           failureThreshold: 5
         terminationMessagePath: /dev/termination-log
         imagePullPolicy: Always
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi

--- a/tests/sm-dummy/charts/sm-dummy/values.yaml
+++ b/tests/sm-dummy/charts/sm-dummy/values.yaml
@@ -24,13 +24,6 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container Security Context to be set on the controller component container
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
 
 serviceAccount:
   create: true


### PR DESCRIPTION
### Description
* Apply Kubernetes container security hardening to site-manager Helm chart 

### Solution
* Hardens container securityContext across site-manager, paas-geo-monitor, and sm-dummy deployments
* Adds mandatory /tmp emptyDir mount to every pod
* Hardens docker-compose test stack with read-only root filesystem

### Changes

- `_helpers.tpl` — replaced OpenShift capability detection with PAAS_PLATFORM == KUBERNETES, fixed runAsUser: 10001 → 1001, added runAsGroup: 1001
- `deployment.yaml` + `paas-geo-monitor-deployment.yaml` — added full container securityContext, added /tmp emptyDir
- `values.yaml` — removed overridable containerSecurityContext block
- `sm-dummy chart` — same hardening + PYTHONDONTWRITEBYTECODE=1
- `docker-compose.yaml` — read_only: true + tmpfs: /tmp on all services
- `sm-dummy/values.yaml` — removed containerSecurityContext block (same as main chart)