### PR TITLE
fix - Add Labels on Kubernetes Objects

### DIFF
--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -41,8 +41,9 @@ IP addresses used to generate SSL certificate with "Subject Alternative Name" fi
 {{- define "securityContext" -}}
     securityContext:
         {{- .Values.securityContext | toYaml | nindent 8  }}
-        {{- if and (not .Values.securityContext.runAsUser) (not (.Capabilities.APIVersions.Has "apps.openshift.io/v1")) }}
-        runAsUser: 10001
+        {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+        runAsUser: 1001
+        runAsGroup: 1001
         {{- end -}}
 {{- end -}}
 

--- a/charts/site-manager/templates/_helpers.tpl
+++ b/charts/site-manager/templates/_helpers.tpl
@@ -1,4 +1,20 @@
 {{/*
+Find Docker image — checks deployDescriptor (NC Application Deployer) first, falls back to default.
+Dictionary keys: SERVICE_NAME, vals (.Values), default (fallback image string)
+*/}}
+{{- define "find_image" -}}
+  {{- $image := .default -}}
+  {{- if .vals.ignoreDeployDescriptor -}}
+    {{/* just skip and use default */}}
+  {{- else if .vals.deployDescriptor -}}
+    {{- if index .vals.deployDescriptor .SERVICE_NAME -}}
+      {{- $image = (index .vals.deployDescriptor .SERVICE_NAME "image") -}}
+    {{- end -}}
+  {{- end -}}
+  {{ printf "%s" $image }}
+{{- end -}}
+
+{{/*
 Return the appropriate host for ingress.
 */}}
 {{- define "site-manager.ingress.host" -}}

--- a/charts/site-manager/templates/deployment.yaml
+++ b/charts/site-manager/templates/deployment.yaml
@@ -4,6 +4,17 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.SERVICE_NAME }}
+  labels:
+    name: site-manager
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/instance: '{{ cat (coalesce .Values.DEPLOYMENT_RESOURCE_NAME .Values.SERVICE_NAME) "-" .Values.NAMESPACE | nospace | trunc 63 | trimSuffix "-" }}'
+    app.kubernetes.io/version: '{{ .Values.ARTIFACT_DESCRIPTOR_VERSION }}'
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    app.kubernetes.io/technology: go
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -13,6 +24,15 @@ spec:
     metadata:
       labels:
         app: site-manager
+        {{- if .Values.SERVICE_NAME }}
+        name: site-manager
+        app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+        app.kubernetes.io/instance: '{{ cat (coalesce .Values.DEPLOYMENT_RESOURCE_NAME .Values.SERVICE_NAME) "-" .Values.NAMESPACE | nospace | trunc 63 | trimSuffix "-" }}'
+        app.kubernetes.io/version: '{{ .Values.ARTIFACT_DESCRIPTOR_VERSION }}'
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+        app.kubernetes.io/technology: go
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- with .Values.priorityClassName }}
@@ -35,7 +55,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           readOnlyRootFilesystem: true
-        image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
+        image: {{ template "find_image" (dict "SERVICE_NAME" "site-manager" "vals" .Values "default" (printf "%s:%s" .Values.image.repository .Values.image.tag)) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - "--bind=0.0.0.0:8443"

--- a/charts/site-manager/templates/deployment.yaml
+++ b/charts/site-manager/templates/deployment.yaml
@@ -22,10 +22,19 @@ spec:
       {{ include  "securityContext" . }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
@@ -78,6 +87,8 @@ spec:
           - mountPath: /rest-api
             name: rest-api-token
             readOnly: true
+          - mountPath: /tmp
+            name: tmp
         resources:
           limits:
             cpu: "{{ .Values.limits.cpu }}"
@@ -107,6 +118,9 @@ spec:
         terminationMessagePath: /dev/termination-log
         imagePullPolicy: {{ .Values.image.pullPolicy }}
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
         - name: sm-certs
           secret:
             secretName: sm-certs

--- a/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
+++ b/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
@@ -3,6 +3,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: paas-geo-monitor
+  {{- if .Values.SERVICE_NAME }}
+  labels:
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/instance: '{{ cat (coalesce .Values.DEPLOYMENT_RESOURCE_NAME .Values.SERVICE_NAME) "-" .Values.NAMESPACE | nospace | trunc 63 | trimSuffix "-" }}'
+    app.kubernetes.io/version: '{{ .Values.ARTIFACT_DESCRIPTOR_VERSION }}'
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    app.kubernetes.io/technology: go
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -12,6 +22,14 @@ spec:
     metadata:
       labels:
         app: paas-geo-monitor
+        {{- if .Values.SERVICE_NAME }}
+        app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+        app.kubernetes.io/instance: '{{ cat (coalesce .Values.DEPLOYMENT_RESOURCE_NAME .Values.SERVICE_NAME) "-" .Values.NAMESPACE | nospace | trunc 63 | trimSuffix "-" }}'
+        app.kubernetes.io/version: '{{ .Values.ARTIFACT_DESCRIPTOR_VERSION }}'
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+        app.kubernetes.io/technology: go
+        {{- end }}
     spec:
       serviceAccount: paas-geo-monitor
       automountServiceAccountToken: false
@@ -34,7 +52,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           readOnlyRootFilesystem: true
-        image: {{ .Values.paasGeoMonitor.image}}
+        image: {{ template "find_image" (dict "SERVICE_NAME" "paas-geo-monitor" "vals" .Values "default" .Values.paasGeoMonitor.image) }}
         imagePullPolicy: Always
         args:
           - "--config=/config/config.yaml"

--- a/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
+++ b/charts/site-manager/templates/paas-geo-monitor-deployment.yaml
@@ -21,10 +21,19 @@ spec:
       {{ include  "securityContext" . }}
       containers:
       - name: paas-geo-monitor
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ .Values.paasGeoMonitor.image}}
         imagePullPolicy: Always
         args:
@@ -57,6 +66,8 @@ spec:
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: serviceaccount-token
             readOnly: true
+          - mountPath: /tmp
+            name: tmp
         resources:
           limits:
               cpu: "20m"
@@ -85,6 +96,9 @@ spec:
           successThreshold: 1
           failureThreshold: 5
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
         - name: config
           configMap:
             name: paas-geo-monitor-cfg

--- a/charts/site-manager/values.yaml
+++ b/charts/site-manager/values.yaml
@@ -31,14 +31,6 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container Security Context to be set on the controller component container
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
-  readOnlyRootFilesystem: true
 
 serviceAccount:
   create: true

--- a/tests/docker-compose/docker-compose.yaml
+++ b/tests/docker-compose/docker-compose.yaml
@@ -12,9 +12,13 @@ services:
     image: sm-dummy
     container_name: serviceA-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
       - SMA_DEBUG=True
       - SMA_INIT_MODE=active
+      - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -25,9 +29,13 @@ services:
     image: sm-dummy
     container_name: serviceB-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -38,9 +46,13 @@ services:
     image: sm-dummy
     container_name: serviceC-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -51,9 +63,13 @@ services:
     image: sm-dummy
     container_name: custom-service-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=active
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -66,11 +82,14 @@ services:
     image: site-manager
     container_name: site-manager-1
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - ./site-manager-config.yaml:/val/config.yaml
     command:
       - "--bind=0.0.0.0:8080"
-    environment: 
+    environment:
       - SM_CONFIG_FILE=/val/config.yaml
       - SM_DEBUG=True
       - FRONT_HTTP_AUTH=True
@@ -88,23 +107,31 @@ services:
     image: sm-dummy
     container_name: serviceA-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
       - SMA_DEBUG=True
       - SMA_INIT_MODE=standby
+      - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
       - "9005:8080"
     networks:
       - cluster-2
-         
+
   serviceB-2:
     image: sm-dummy
     container_name: serviceB-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -115,9 +142,13 @@ services:
     image: sm-dummy
     container_name: serviceC-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -128,9 +159,13 @@ services:
     image: sm-dummy
     container_name: custom-service-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     environment:
         - SMA_DEBUG=True
         - SMA_INIT_MODE=standby
+        - PYTHONDONTWRITEBYTECODE=1
     expose:
       - 8080
     ports:
@@ -143,11 +178,14 @@ services:
     image: site-manager
     container_name: site-manager-2
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - ./site-manager-config-2.yaml:/val/config.yaml
     command:
       - "--bind=0.0.0.0:8080"
-    environment: 
+    environment:
       - SM_CONFIG_FILE=/val/config.yaml
       - SM_DEBUG=True
       - FRONT_HTTP_AUTH=True

--- a/tests/sm-dummy/charts/sm-dummy/templates/deployment.yaml
+++ b/tests/sm-dummy/charts/sm-dummy/templates/deployment.yaml
@@ -20,13 +20,26 @@ spec:
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+        {{- if eq (default "" $.Values.PAAS_PLATFORM) "KUBERNETES" }}
+        runAsUser: 1001
+        runAsGroup: 1001
+        {{- end }}
       {{- end }}
       containers:
       - name: sm-dummy
-        {{- with .Values.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
+          runAsNonRoot: true
+          {{- if eq (default "" $.Values.PAAS_PLATFORM) "KUBERNETES" }}
+          runAsUser: 1001
+          runAsGroup: 1001
+          {{- end }}
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         image: {{ .Values.image }}
         env:
           - name: SMA_TIMEOUT
@@ -55,6 +68,11 @@ spec:
           - name: SMA_CUSTOM_AUDIENCE
             value: '{{ .Values.env.SMA_CUSTOM_AUDIENCE }}'
             {{- end }}
+          - name: PYTHONDONTWRITEBYTECODE
+            value: "1"
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
         ports:
         - containerPort: 8080
           protocol: TCP
@@ -83,3 +101,7 @@ spec:
           failureThreshold: 5
         terminationMessagePath: /dev/termination-log
         imagePullPolicy: Always
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi

--- a/tests/sm-dummy/charts/sm-dummy/values.yaml
+++ b/tests/sm-dummy/charts/sm-dummy/values.yaml
@@ -24,13 +24,6 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container Security Context to be set on the controller component container
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
 
 serviceAccount:
   create: true


### PR DESCRIPTION
### Description

Adds `app.kubernetes.io/*` standard labels to Deployment resources and introduces the `find_image` helper to support image override via `deployDescriptor`.

### Chnages

* Added `find_image` Helm helper to `_helpers.tpl` — checks `deployDescriptor` for image override, falls back to the default image value
* Added `app.kubernetes.io/*` labels (`name`, `instance`, `version`, `component`, `part-of`, `managed-by`, `technology`) to `metadata.labels` and `spec.template.metadata.labels` on both `site-manager` and `paas-geo-monitor` Deployments
* Labels are guarded by `{{- if .Values.SERVICE_NAME }}` so deployments without these values set are unaffected
* Switched image reference in both Deployment templates to use `find_image` instead of a direct value reference


> **Dependency:** This branch is based on [#219](https://github.com/Netcracker/DRNavigator/pull/219) (security hardening). Merge #219 first, then merge this PR.