### PR TITLE
Add values.schema.json

### DIFF
--- a/charts/site-manager/templates/ingress.yaml
+++ b/charts/site-manager/templates/ingress.yaml
@@ -19,6 +19,12 @@ metadata:
     {{- end }}
   labels:
     app: {{ .Chart.Name }}
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/component: 'backend'
+    app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    deployment.netcracker.com/ingress-audience-type: "ops-user"
+    deployment.netcracker.com/ingress-type: "private-network"
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/site-manager/templates/service.yaml
+++ b/charts/site-manager/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: site-manager
+    name: site-manager
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/part-of: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
   annotations:
     {{- if and (not .Values.tls.ca) ( eq .Values.tls.generateCerts.executor "openshift" ) }}
     service.alpha.openshift.io/serving-cert-secret-name: "sm-certs" # for openshift 3.X

--- a/charts/site-manager/values.schema.json
+++ b/charts/site-manager/values.schema.json
@@ -94,7 +94,6 @@
     },
     "serviceAccount": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "create": {
           "$ref": "#/definitions/booleanOrString"
@@ -106,7 +105,6 @@
     },
     "ingress": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "create": {
           "$ref": "#/definitions/booleanOrString"
@@ -121,7 +119,6 @@
     },
     "image": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "repository": {
           "type": "string"
@@ -148,7 +145,6 @@
     },
     "crd": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "install": {
           "$ref": "#/definitions/booleanOrString"
@@ -157,7 +153,6 @@
     },
     "env": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "FRONT_HTTP_AUTH": {
           "$ref": "#/definitions/booleanOrString"
@@ -193,7 +188,6 @@
     },
     "tls": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "$ref": "#/definitions/booleanOrString"
@@ -212,7 +206,6 @@
         },
         "generateCerts": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "executor": {
               "type": "string",
@@ -226,7 +219,6 @@
             },
             "subjectAlternativeName": {
               "type": "object",
-              "additionalProperties": false,
               "properties": {
                 "additionalDnsNames": {
                   "type": "array",
@@ -248,7 +240,6 @@
     },
     "paasGeoMonitor": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "install": {
           "$ref": "#/definitions/booleanOrString"
@@ -258,7 +249,6 @@
         },
         "monitoring": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "serviceCIDRRegex": {
               "type": "string"
@@ -267,7 +257,6 @@
         },
         "env": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "PAAS_PING_PEERS": {
               "$ref": "#/definitions/booleanOrString"
@@ -291,7 +280,6 @@
         },
         "config": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "port": {
               "$ref": "#/definitions/integerOrString"
@@ -300,14 +288,12 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "additionalProperties": false,
                 "properties": {
                   "name": {
                     "type": "string"
                   },
                   "clusterIp": {
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
                       "name": {
                         "type": "string"

--- a/charts/site-manager/values.schema.json
+++ b/charts/site-manager/values.schema.json
@@ -157,13 +157,13 @@
       "additionalProperties": true,
       "properties": {
         "FRONT_HTTP_AUTH": {
-          "type": "string"
+          "$ref": "#/definitions/booleanOrString"
         },
         "BACK_HTTP_AUTH": {
-          "type": "string"
+          "$ref": "#/definitions/booleanOrString"
         },
         "SM_DEBUG": {
-          "type": "string"
+          "$ref": "#/definitions/booleanOrString"
         },
         "SM_GROUP": {
           "type": "string"
@@ -261,22 +261,22 @@
           "type": "object",
           "properties": {
             "PAAS_PING_PEERS": {
-              "type": "string"
+              "$ref": "#/definitions/booleanOrString"
             },
             "PAAS_PING_TIME": {
-              "type": "string"
+              "$ref": "#/definitions/integerOrString"
             },
             "PAAS_DEBUG": {
-              "type": "string"
+              "$ref": "#/definitions/booleanOrString"
             },
             "PAAS_BGP_METRICS": {
-              "type": "string"
+              "$ref": "#/definitions/booleanOrString"
             },
             "PAAS_BGP_CHECK_PERIOD": {
-              "type": "string"
+              "$ref": "#/definitions/integerOrString"
             },
             "PAAS_BGP_CHECK_TIMEOUT": {
-              "type": "string"
+              "$ref": "#/definitions/integerOrString"
             }
           }
         },

--- a/charts/site-manager/values.schema.json
+++ b/charts/site-manager/values.schema.json
@@ -1,0 +1,322 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "booleanOrString": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "integerOrString": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "createClusterAdminEntities": {
+      "$ref": "#/definitions/booleanOrString"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string",
+      "enum": ["small", "medium", "large"]
+    },
+    "smSecureAuth": {
+      "$ref": "#/definitions/booleanOrString"
+    },
+    "customAudience": {
+      "type": "string"
+    },
+    "MONITORING_ENABLED": {
+      "$ref": "#/definitions/booleanOrString"
+    },
+    "SERVICE_NAME": {
+      "type": "string"
+    },
+    "MANAGED_BY": {
+      "type": "string"
+    },
+    "GATEWAY_SYSTEM_NAME": {
+      "type": "string"
+    },
+    "GATEWAY_SYSTEM_NAMESPACE": {
+      "type": "string"
+    },
+    "PAAS_PLATFORM": {
+      "type": "string",
+      "enum": ["KUBERNETES", "OPENSHIFT"]
+    },
+    "DBAAS_ENABLED": {
+      "$ref": "#/definitions/booleanOrString"
+    },
+    "CLOUD_PUBLIC_HOST": {
+      "type": "string"
+    },
+    "ignoreDeployDescriptor": {
+      "$ref": "#/definitions/booleanOrString"
+    },
+    "DEPLOYMENT_RESOURCE_NAME": {
+      "type": "string"
+    },
+    "NAMESPACE": {
+      "type": "string"
+    },
+    "ARTIFACT_DESCRIPTOR_VERSION": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "workerCount": {
+      "$ref": "#/definitions/integerOrString"
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "affinity": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "$ref": "#/definitions/booleanOrString"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "$ref": "#/definitions/booleanOrString"
+        },
+        "name": {
+          "type": "string"
+        },
+        "className": {
+          "type": "string"
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "requests": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "deployDescriptor": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "crd": {
+      "type": "object",
+      "properties": {
+        "install": {
+          "$ref": "#/definitions/booleanOrString"
+        }
+      }
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "FRONT_HTTP_AUTH": {
+          "type": "string"
+        },
+        "BACK_HTTP_AUTH": {
+          "type": "string"
+        },
+        "SM_DEBUG": {
+          "type": "string"
+        },
+        "SM_GROUP": {
+          "type": "string"
+        },
+        "SM_KIND": {
+          "type": "string"
+        },
+        "SM_KIND_LIST": {
+          "type": "string"
+        },
+        "HTTP_SCHEME": {
+          "type": "string"
+        },
+        "SM_CACERT": {
+          "type": "string"
+        },
+        "SM_GET_REQUEST_TIMEOUT": {
+          "$ref": "#/definitions/integerOrString"
+        },
+        "SM_POST_REQUEST_TIMEOUT": {
+          "$ref": "#/definitions/integerOrString"
+        }
+      }
+    },
+    "tls": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "$ref": "#/definitions/booleanOrString"
+        },
+        "crt": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "ca": {
+          "type": "string"
+        },
+        "defaultIngressTls": {
+          "$ref": "#/definitions/booleanOrString"
+        },
+        "generateCerts": {
+          "type": "object",
+          "properties": {
+            "executor": {
+              "type": "string",
+              "enum": ["cert-manager", "openshift"]
+            },
+            "clusterIssuerName": {
+              "type": "string"
+            },
+            "duration": {
+              "$ref": "#/definitions/integerOrString"
+            },
+            "subjectAlternativeName": {
+              "type": "object",
+              "properties": {
+                "additionalDnsNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "additionalIpAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "paasGeoMonitor": {
+      "type": "object",
+      "properties": {
+        "install": {
+          "$ref": "#/definitions/booleanOrString"
+        },
+        "image": {
+          "type": "string"
+        },
+        "monitoring": {
+          "type": "object",
+          "properties": {
+            "serviceCIDRRegex": {
+              "type": "string"
+            }
+          }
+        },
+        "env": {
+          "type": "object",
+          "properties": {
+            "PAAS_PING_PEERS": {
+              "type": "string"
+            },
+            "PAAS_PING_TIME": {
+              "type": "string"
+            },
+            "PAAS_DEBUG": {
+              "type": "string"
+            },
+            "PAAS_BGP_METRICS": {
+              "type": "string"
+            },
+            "PAAS_BGP_CHECK_PERIOD": {
+              "type": "string"
+            },
+            "PAAS_BGP_CHECK_TIMEOUT": {
+              "type": "string"
+            }
+          }
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "$ref": "#/definitions/integerOrString"
+            },
+            "peers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "clusterIp": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "svcPort": {
+                        "$ref": "#/definitions/integerOrString"
+                      },
+                      "podPort": {
+                        "$ref": "#/definitions/integerOrString"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/site-manager/values.schema.json
+++ b/charts/site-manager/values.schema.json
@@ -94,6 +94,7 @@
     },
     "serviceAccount": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "create": {
           "$ref": "#/definitions/booleanOrString"
@@ -105,6 +106,7 @@
     },
     "ingress": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "create": {
           "$ref": "#/definitions/booleanOrString"
@@ -119,7 +121,7 @@
     },
     "image": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "repository": {
           "type": "string"
@@ -146,6 +148,7 @@
     },
     "crd": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "install": {
           "$ref": "#/definitions/booleanOrString"
@@ -154,7 +157,7 @@
     },
     "env": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "FRONT_HTTP_AUTH": {
           "$ref": "#/definitions/booleanOrString"
@@ -190,6 +193,7 @@
     },
     "tls": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enabled": {
           "$ref": "#/definitions/booleanOrString"
@@ -208,6 +212,7 @@
         },
         "generateCerts": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "executor": {
               "type": "string",
@@ -221,6 +226,7 @@
             },
             "subjectAlternativeName": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "additionalDnsNames": {
                   "type": "array",
@@ -242,6 +248,7 @@
     },
     "paasGeoMonitor": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "install": {
           "$ref": "#/definitions/booleanOrString"
@@ -251,6 +258,7 @@
         },
         "monitoring": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "serviceCIDRRegex": {
               "type": "string"
@@ -259,6 +267,7 @@
         },
         "env": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "PAAS_PING_PEERS": {
               "$ref": "#/definitions/booleanOrString"
@@ -282,6 +291,7 @@
         },
         "config": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "port": {
               "$ref": "#/definitions/integerOrString"
@@ -290,12 +300,14 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "name": {
                     "type": "string"
                   },
                   "clusterIp": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                       "name": {
                         "type": "string"

--- a/ci/cloud-tests/cluster.yaml
+++ b/ci/cloud-tests/cluster.yaml
@@ -47,9 +47,9 @@ plugins:
                 install: false
               ingress:
                 name: site-manager.test-local-k8s.com
-                limits:
-                  cpu: "150m"
-                  memory: "150Mi"
+              limits:
+                cpu: "150m"
+                memory: "150Mi"
               image:
                 repository: ghcr.io/netcracker/site-manager
                 tag: <SM_TAG>

--- a/ci/cloud-tests/cluster.yaml
+++ b/ci/cloud-tests/cluster.yaml
@@ -47,9 +47,6 @@ plugins:
                 install: false
               ingress:
                 name: site-manager.test-local-k8s.com
-              limits:
-                cpu: "150m"
-                memory: "150Mi"
               image:
                 repository: ghcr.io/netcracker/site-manager
                 tag: <SM_TAG>


### PR DESCRIPTION
### Problem
It is required to introduce `values.schema.json` for the chart

### Solution
* Added `values.schema.json`
    * Did not add description for the fields, since it would introduce duplication
    * Allowed additional properties to keep backward compatibility
    * Schema is detailed for SM-owned parameters, for others it is generic objects/arrays/etc
* Added missing labels required by release window

### Test Cases
1. Make sure SiteManager deploys OK with both AppDeployer/ArgoCD
2. Make sure SiteManager schema validation fails if some incorrect types are specified

Example incorrect values:
```
createClusterAdminEntities: 123
```

Expected error:
```
$ helm template charts/site-manager/ -f env~/values.yaml 
Error: values don't meet the specifications of the schema(s) in the following chart(s):
site-manager:
- at '/createClusterAdminEntities': 'anyOf' failed
  - at '/createClusterAdminEntities': got number, want boolean
  - at '/createClusterAdminEntities': got number, want string
```