### PR TITLE
Fix CI cloud-test

### DIFF
--- a/ci/cloud-tests/cluster.yaml
+++ b/ci/cloud-tests/cluster.yaml
@@ -11,6 +11,10 @@ nodes:
 cluster_name: "test-local-k8s.com"
 
 services:
+  packages:
+    associations:
+      containerd:
+        package_name: containerd=2.2*
   cri:
     containerRuntime: containerd
     containerdConfig:


### PR DESCRIPTION
### Problem
Since Ubuntu removed containerd 1.7 from their repos, all KubeMarine installations which install containerd started failing. Need to fix DRNavigator CI by explicitly setting containerd 2.2
* https://github.com/Netcracker/DRNavigator/actions/runs/28425131368

```
2026-06-30 06:41:33,195 CRITICAL 	Package containerd is a virtual package provided by:
2026-06-30 06:41:33,195 CRITICAL 	  containerd.io 2.2.5-1~ubuntu.22.04~jammy
2026-06-30 06:41:33,195 CRITICAL 	
2026-06-30 06:41:33,195 CRITICAL 	E: Version '1.7.*' for 'containerd' was not found
```