### PR TITLE
[CPCAP-10963] Support installing two Site-Mangers on one cluster

### DIFF
--- a/charts/site-manager/templates/cluster-role-binding.yaml
+++ b/charts/site-manager/templates/cluster-role-binding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}:{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}:{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/charts/site-manager/templates/cluster-role.yaml
+++ b/charts/site-manager/templates/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}:{{ .Release.Namespace }}
 rules:
   - apiGroups: ["{{ .Values.env.SM_GROUP }}"]
     resources: [{{ printf "%ss" (lower .Values.env.SM_KIND) }}]

--- a/documentation/public/installation.md
+++ b/documentation/public/installation.md
@@ -8,6 +8,7 @@
     * [Certificates Prerequisite](#certificates-prerequisite)
     * [Installation](#installation)
     * [Certificate Renewal Procedure](#certificate-renewal-procedure)
+    * [Installing Second Site-Manager](#installing-second-site-manager)
   * [Paas-Geo-Monitor](#paas-geo-monitor)
     * [Installation Procedure](#installation-procedure)
     * [Configuration](#configuration)
@@ -309,7 +310,7 @@ To renew a certificate:
 
 ### Installing Second Site-Manager
 
-Sometimes it is requires to install two Site-Managers in one cluster. This may look as following:
+Sometimes it is required to install two Site-Managers in one cluster. This may look as following:
 * First one is system Site-Manager, i.e. the main one, which is installed on cluster to provide SiteManager CRs API to other applications.
 * Second one is CI Site-Manager, i.e. the one used for CI/testing purposes.
 

--- a/documentation/public/installation.md
+++ b/documentation/public/installation.md
@@ -307,6 +307,18 @@ To renew a certificate:
 
 4. Update `config.yml` (Token and path cacert).
 
+### Installing Second Site-Manager
+
+Sometimes it is requires to install two Site-Managers in one cluster. This may look as following:
+* First one is system Site-Manager, i.e. the main one, which is installed on cluster to provide SiteManager CRs API to other applications.
+* Second one is CI Site-Manager, i.e. the one used for CI/testing purposes.
+
+To install two Site-Managers you should do the following:
+* Install system Site-Manager as usual. You should deploy CRDs/webhooks with this system Site-Manager.
+* Install CI Site-Manager without CRDs/webhooks, i.e set `crd.install` to `false`, since those will be brought by system Site-Manager. Otherwise installation is the same. You still need to provide certificates as described in [Certificates Prerequisite](#certificates-prerequisite). Note that CI Site-Manager service name will be different, so system Site-Manager certificates may not work.
+
+Note that when two Site-Managers are installed, they both may process all CRs in the cluster, i.e. there is no `watchNamespaces` support. For now this is fine for Site-Manager case.
+
 ## Paas-Geo-Monitor
 
 ### Installation Procedure

--- a/documentation/public/installation.md
+++ b/documentation/public/installation.md
@@ -310,15 +310,15 @@ To renew a certificate:
 
 ### Installing Second Site-Manager
 
-Sometimes it is required to install two Site-Managers in one cluster. This may look as following:
+Sometimes, it is required to install two Site-Managers in one cluster. This may look as follows:
 * First one is system Site-Manager, i.e. the main one, which is installed on cluster to provide SiteManager CRs API to other applications.
 * Second one is CI Site-Manager, i.e. the one used for CI/testing purposes.
 
-To install two Site-Managers you should do the following:
-* Install system Site-Manager as usual. You should deploy CRDs/webhooks with this system Site-Manager.
-* Install CI Site-Manager without CRDs/webhooks, i.e set `crd.install` to `false`, since those will be brought by system Site-Manager. Otherwise installation is the same. You still need to provide certificates as described in [Certificates Prerequisite](#certificates-prerequisite). Note that CI Site-Manager service name will be different, so system Site-Manager certificates may not work.
+To install two Site-Managers, perform the following:
+1. Install system Site-Manager as usual. You should deploy CRDs/webhooks with this system Site-Manager.
+2. Install CI Site-Manager without CRDs/webhooks, i.e set `crd.install` to `false`, since those will be brought by system Site-Manager. Otherwise, installation is the same. You still need to provide the certificates as described in [Certificates Prerequisite](#certificates-prerequisite). Note that CI Site-Manager service name will be different, so the system Site-Manager certificates may not work.
 
-Note that when two Site-Managers are installed, they both may process all CRs in the cluster, i.e. there is no `watchNamespaces` support. For now this is fine for Site-Manager case.
+**Note**: When two Site-Managers are installed, they both may process all CRs in the cluster, i.e. there is no `watchNamespaces` support. For now this is fine for Site-Manager case.
 
 ## Paas-Geo-Monitor
 


### PR DESCRIPTION
### Problem
For CI purposes, it is required to support installing two Site-Managers on one cluster

### Solution
* Changed ClusterRole/Binding to use namespaced name
* Added doc section to describe how to install two Site-Managers