### PR TITLE
[CPCAP-9414] feat: add helm-charts-release workflow and release-drafter config 

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,50 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+
+categories:
+  - title: '💥 Breaking Changes'
+    labels:
+      - breaking-change
+      - BREAKING
+  - title: '💡 New Features'
+    labels:
+      - feature
+      - enhancement
+  - title: '🐞 Bug Fixes'
+    labels:
+      - bug
+      - fix
+      - bugfix
+  - title: '⚙️ Technical Debt'
+    labels:
+      - refactor
+  - title: '📝 Documentation'
+    labels:
+      - documentation
+      - doc
+
+change-template: "- (#$NUMBER) $TITLE by @$AUTHOR"
+
+no-changes-template: 'No significant changes'
+
+template: |
+  ## 🚀 Release
+
+  ### What's Changed
+  $CHANGES
+
+  ---
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -1,0 +1,67 @@
+name: Helm Charts Release
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Release version (e.g. v0.35.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+run-name: ${{ github.repository }} Release ${{ inputs.release }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-transfer-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sm-charts-transfer
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/docker-charts/Dockerfile
+          push: true
+          tags: ghcr.io/netcracker/sm-charts-transfer:${{ inputs.release }}
+          provenance: false
+
+  github-release:
+    needs: [build-transfer-image]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub release
+        uses: netcracker/release-drafter@86f4276a3894b5af70480e826c32fe3648ac6a70  # v1.0.0
+        with:
+          config-name: release-drafter-config.yml
+          publish: true
+          name: ${{ inputs.release }}
+          tag: ${{ inputs.release }}
+          version: ${{ inputs.release }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 run-name: ${{ github.repository }} Release ${{ inputs.release }}
 
@@ -18,36 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-transfer-image:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push sm-charts-transfer
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ci/docker-charts/Dockerfile
-          push: true
-          tags: ghcr.io/netcracker/sm-charts-transfer:${{ inputs.release }}
-          provenance: false
-
   github-release:
-    needs: [build-transfer-image]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow and release-drafter config to support automated releases triggered from the GitLab site-manager pipeline.

## Chnages

- `.github/workflows/helm-charts-release.yaml` — triggered via `workflow_dispatch`  from GitLab CI on tag push. Builds and pushes the `sm-charts-transfer` Docker image tagged with the release version, then creates a GitHub release using release-drafter.

- `.github/release-drafter-config.yml` — maps PR labels to release categories (Breaking Changes, Features, Bug Fixes, Technical Debt, Documentation).