### PR TITLE
fix: chain publish workflow via workflow_dispatch to build all release images

### DIFF
--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -18,7 +18,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publish-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger and wait for publish workflow
+        run: |
+          DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          gh workflow run publish.yaml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            --field tag=${{ inputs.release }}
+
+          echo "Waiting for the dispatched run to appear..."
+          for i in $(seq 1 30); do
+            RUN_ID=$(gh run list \
+              --repo ${{ github.repository }} \
+              --workflow publish.yaml \
+              --json databaseId,createdAt,event \
+              --jq "[.[] | select(.event == \"workflow_dispatch\" and .createdAt >= \"$DISPATCH_TIME\")] | sort_by(.createdAt) | .[0].databaseId")
+            [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] && break
+            sleep 10
+          done
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "Timed out waiting for publish.yaml run to appear"
+            exit 1
+          fi
+
+          echo "Watching run $RUN_ID"
+          gh run watch "$RUN_ID" --repo ${{ github.repository }} --exit-status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   github-release:
+    needs: [publish-artifacts]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,16 +70,3 @@ jobs:
           version: ${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-artifacts:
-    needs: [github-release]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger publish workflow
-        run: |
-          gh workflow run publish.yaml \
-            --repo ${{ github.repository }} \
-            --ref main \
-            --field tag=${{ inputs.release }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 run-name: ${{ github.repository }} Release ${{ inputs.release }}
 
@@ -19,37 +18,10 @@ concurrency:
 
 jobs:
   publish-artifacts:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger and wait for publish workflow
-        run: |
-          DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-          gh workflow run publish.yaml \
-            --repo ${{ github.repository }} \
-            --ref main \
-            --field tag=${{ inputs.release }}
-
-          echo "Waiting for the dispatched run to appear..."
-          for i in $(seq 1 30); do
-            RUN_ID=$(gh run list \
-              --repo ${{ github.repository }} \
-              --workflow publish.yaml \
-              --json databaseId,createdAt,event \
-              --jq "[.[] | select(.event == \"workflow_dispatch\" and .createdAt >= \"$DISPATCH_TIME\")] | sort_by(.createdAt) | .[0].databaseId")
-            [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] && break
-            sleep 10
-          done
-
-          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-            echo "Timed out waiting for publish.yaml run to appear"
-            exit 1
-          fi
-
-          echo "Watching run $RUN_ID"
-          gh run watch "$RUN_ID" --repo ${{ github.repository }} --exit-status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag: ${{ inputs.release }}
+    secrets: inherit
 
   github-release:
     needs: [publish-artifacts]

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 run-name: ${{ github.repository }} Release ${{ inputs.release }}
 
@@ -35,3 +36,16 @@ jobs:
           version: ${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-artifacts:
+    needs: [github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger publish workflow
+        run: |
+          gh workflow run publish.yaml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            --field tag=${{ inputs.release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 run-name: ${{ github.repository }} Release ${{ inputs.release }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,14 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.35.2)"
+        required: true
+        type: string
 env:
-  TAG_NAME: ${{ github.event.release.tag_name || (github.ref == 'refs/heads/main' && 'main') }}
+  TAG_NAME: ${{ github.event.inputs.tag || github.event.release.tag_name || (github.ref == 'refs/heads/main' && 'main') }}
 
 jobs:
   publish-docker:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,14 @@ on:
         description: "Release tag to publish (e.g. v0.35.2)"
         required: true
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.35.2)"
+        required: true
+        type: string
 env:
-  TAG_NAME: ${{ github.event.inputs.tag || github.event.release.tag_name || (github.ref == 'refs/heads/main' && 'main') }}
+  TAG_NAME: ${{ inputs.tag || github.event.release.tag_name || (github.ref == 'refs/heads/main' && 'main') }}
 
 jobs:
   publish-docker:
@@ -42,8 +48,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.TAG_NAME }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary
Fix image publishing for versioned releases by dispatching `publish.yaml` via `workflow_dispatch` 
- fixes CPCAP-9414
## Problem
The previous approach removed `build-transfer-image` from `helm-charts-release.yaml` assuming `publish.yaml` would fire via the `release: created` event. This does not work — GitHub explicitly prevents workflows using `GITHUB_TOKEN` from triggering other workflow events to avoid recursive runs. As a result, no images were built for versioned release tags.

## Changes
- `helm-charts-release.yaml` — replaces the inline `build-transfer-image` job with a `publish-artifacts` job that dispatches publish.yaml` via `workflow_dispatch` after the GitHub release is created. `workflow_dispatch` is explicitly exempt from the `GITHUB_TOKEN` restriction per GitHub docs.
- `publish.yaml` — adds `workflow_dispatch` trigger with a `tag` input so it can be called programmatically. `TAG_NAME` resolution now also covers the dispatch input.